### PR TITLE
Add CI and upgrade ether package to v6

### DIFF
--- a/.changeset/spotty-jeans-add.md
+++ b/.changeset/spotty-jeans-add.md
@@ -1,0 +1,5 @@
+---
+"@fake-scope/fake-pkg": patch
+---
+
+add ci & upgrade ether from v.5 to v.6 

--- a/.changeset/spotty-jeans-add.md
+++ b/.changeset/spotty-jeans-add.md
@@ -2,4 +2,4 @@
 "@fake-scope/fake-pkg": patch
 ---
 
-add ci & upgrade ether from v.5 to v.6 
+Add CI and upgrade ethers from v5 to v6


### PR DESCRIPTION
Added CI configuration and upgraded ether package from version 5 to 6.

## Summary by Sourcery

Chores:
- Add a changeset entry documenting the CI setup and ether upgrade as a patch release for @fake-scope/fake-pkg.